### PR TITLE
Update autoload for composer from psr-0 to psr-4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "autoload": {
-        "psr-0": {
-            "HelgeSverre\\Brreg": "src/"
+        "psr-4": {
+            "HelgeSverre\\Brreg\\": "src/"
         }
     }
 }


### PR DESCRIPTION
As composer version 1.x has been warning about psr-0 not being followed for a while, I now tried it with composer version 2.x which blew a gasket as it had promised.

Updating from old deprecated psr-0 to psr-4 and appending backslashes seem to silence all composer complaints and it now installs again for me. 